### PR TITLE
Updated Dockerfile to use node:22-slim as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.13.1
+ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-slim AS base
 
 LABEL fly_launch_runtime="NodeJS"


### PR DESCRIPTION
Partially Fixes https://github.com/CheckerNetwork/roadmap/issues/210

Updated the Node.js base image from node:20.13.1-slim to node:22-slim as requested in issue 210 of the roadmap repository.