### PR TITLE
Add depcheck for Unused Dependency Detection

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,0 +1,5 @@
+ignores: [
+  "@types/*",    # Ignore TypeScript type definitions
+  "typescript",  # TypeScript itself is used by the compiler but not imported
+  "depcheck",    # Used in npm scripts but not imported
+]

--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,5 +1,0 @@
-ignores: [
-  "@types/*",    # Ignore TypeScript type definitions
-  "typescript",  # TypeScript itself is used by the compiler but not imported
-  "depcheck",    # Used in npm scripts but not imported
-]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - run: npm run test:types
       - run: npm run test:lint
       - run: npm run test:unit
+      - run: npm run test:deps
 
   dry-run:
     # Don't run on pull requests from forks - they don't have access to secrets

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "debug": "^4.4.0",
                 "drand-client": "^1.2.6",
                 "ethers": "^6.13.5",
-                "ipfs-car": "^2.0.0",
                 "ipfs-unixfs-exporter": "^13.6.1",
                 "just-percentile": "^4.2.0",
                 "k-closest": "^1.3.0",
@@ -34,7 +33,6 @@
             },
             "devDependencies": {
                 "@types/mocha": "^10.0.10",
-                "@types/pg": "^8.11.11",
                 "depcheck": "^1.4.7",
                 "dotenv": "^16.4.7",
                 "mocha": "^11.1.0",
@@ -733,20 +731,6 @@
                 "@ipld/dag-cbor": "^9.0.0",
                 "@ipld/dag-json": "^10.0.0",
                 "multiformats": "^13.3.1"
-            }
-        },
-        "node_modules/@ipld/unixfs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-3.0.0.tgz",
-            "integrity": "sha512-Tj3/BPOlnemcZQ2ETIZAO8hqAs9KNzWyX5J9+JCL9jDwvYwjxeYjqJ3v+9DusNvTBmJhZnGVP6ijUHrsuOLp+g==",
-            "dependencies": {
-                "@ipld/dag-pb": "^4.0.0",
-                "@multiformats/murmur3": "^2.1.3",
-                "@perma/map": "^1.0.2",
-                "actor": "^2.3.1",
-                "multiformats": "^13.0.1",
-                "protobufjs": "^7.1.2",
-                "rabin-rs": "^2.1.0"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -5659,7 +5643,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -6403,43 +6388,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/ipfs-car": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-2.0.0.tgz",
-            "integrity": "sha512-lbp2JdY90yJMVeieVjku7QzgLqHQU6eU63zuWE5ONOzLPpsLkBNM9UxCERyt+0HdEv1SjXStiPnFzL9vfWPpeA==",
-            "license": "Apache-2.0 OR MIT",
-            "dependencies": {
-                "@ipld/car": "^5.1.0",
-                "@ipld/dag-cbor": "^9.0.0",
-                "@ipld/dag-json": "^10.0.1",
-                "@ipld/dag-pb": "^4.0.2",
-                "@ipld/unixfs": "^3.0.0",
-                "@web3-storage/car-block-validator": "^1.0.1",
-                "files-from-path": "^1.0.0",
-                "ipfs-unixfs-exporter": "^13.0.1",
-                "multiformats": "^13.0.1",
-                "sade": "^1.8.1",
-                "varint": "^6.0.0"
-            },
-            "bin": {
-                "🚘": "bin.js",
-                "ipfs-car": "bin.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/ipfs-car/node_modules/files-from-path": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-1.0.2.tgz",
-            "integrity": "sha512-sGHhGxKJ/e52QGF6qRrThkU1tVBIfnFydAP6Ukeg2i/pVDlS3klrWb8azLmh7seqqEiBZfNEWBV9sHgu1RCx5g==",
-            "dependencies": {
-                "graceful-fs": "^4.2.10"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/ipfs-unixfs-exporter": {
@@ -8411,14 +8359,6 @@
             "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
             "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
         },
-        "node_modules/mri": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10262,17 +10202,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/sade": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-            "dependencies": {
-                "mri": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/safe-array-concat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "spark-evaluate",
+    "name": "@filecoin-station/spark-evaluate",
     "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "spark-evaluate",
+            "name": "@filecoin-station/spark-evaluate",
             "version": "1.0.4",
             "dependencies": {
                 "@filecoin-station/spark-impact-evaluator": "^1.2.4",
@@ -35,6 +35,7 @@
             "devDependencies": {
                 "@types/mocha": "^10.0.10",
                 "@types/pg": "^8.11.11",
+                "depcheck": "^1.4.7",
                 "dotenv": "^16.4.7",
                 "mocha": "^11.1.0",
                 "np": "^10.2.0",
@@ -83,17 +84,19 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -177,9 +180,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.0.tgz",
-            "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==",
+            "version": "7.26.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+            "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.26.7"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -226,13 +233,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-            "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+            "version": "7.26.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+            "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.8",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1937,6 +1944,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/pg": {
             "version": "8.11.11",
             "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.11.tgz",
@@ -2104,6 +2118,67 @@
                 "node": ">=16.0.0",
                 "npm": ">=7.0.0"
             }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/shared": "3.5.13",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/compiler-core": "3.5.13",
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.11",
+                "postcss": "^8.4.48",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@web3-storage/access": {
             "version": "20.1.0",
@@ -2582,6 +2657,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/array-includes": {
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
@@ -2600,6 +2685,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/array.prototype.findlast": {
@@ -2713,6 +2808,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arrify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/atomically": {
@@ -3076,6 +3181,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/callsites": {
@@ -3772,6 +3886,237 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/depcheck": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-1.4.7.tgz",
+            "integrity": "sha512-1lklS/bV5chOxwNKA/2XUUk/hPORp8zihZsXflr8x0kLwmcZ9Y9BsS6Hs3ssvA+2wUVbG0U2Ciqvm1SokNjPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.23.0",
+                "@babel/traverse": "^7.23.2",
+                "@vue/compiler-sfc": "^3.3.4",
+                "callsite": "^1.0.0",
+                "camelcase": "^6.3.0",
+                "cosmiconfig": "^7.1.0",
+                "debug": "^4.3.4",
+                "deps-regex": "^0.2.0",
+                "findup-sync": "^5.0.0",
+                "ignore": "^5.2.4",
+                "is-core-module": "^2.12.0",
+                "js-yaml": "^3.14.1",
+                "json5": "^2.2.3",
+                "lodash": "^4.17.21",
+                "minimatch": "^7.4.6",
+                "multimatch": "^5.0.0",
+                "please-upgrade-node": "^3.2.0",
+                "readdirp": "^3.6.0",
+                "require-package-name": "^2.0.1",
+                "resolve": "^1.22.3",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.5.4",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "depcheck": "bin/depcheck.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/depcheck/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/depcheck/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/depcheck/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/depcheck/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/depcheck/node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/depcheck/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/depcheck/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/depcheck/node_modules/minimatch": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/depcheck/node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/depcheck/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/depcheck/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/depcheck/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/depcheck/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/deps-regex": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.2.0.tgz",
+            "integrity": "sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/diff": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -3904,6 +4249,19 @@
             "license": "MIT",
             "dependencies": {
                 "iconv-lite": "^0.6.2"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/env-paths": {
@@ -4557,6 +4915,20 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/esquery": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -4589,6 +4961,13 @@
             "engines": {
                 "node": ">=4.0"
             }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -4687,6 +5066,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "homedir-polyfill": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/external-editor": {
@@ -4859,6 +5251,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/findup-sync": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+            "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^4.0.3",
+                "micromatch": "^4.0.4",
+                "resolve-dir": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
             }
         },
         "node_modules/flat": {
@@ -5120,6 +5528,58 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-prefix/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/global-prefix/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
         "node_modules/globals": {
             "version": "13.21.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
@@ -5346,6 +5806,19 @@
             "dev": true,
             "bin": {
                 "he": "bin/he"
+            }
+        },
+        "node_modules/homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-passwd": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/hosted-git-info": {
@@ -6634,6 +7107,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-wsl": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -7654,6 +8137,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
         "node_modules/meow": {
             "version": "13.2.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -7935,6 +8428,26 @@
             "version": "13.3.1",
             "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
             "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g=="
+        },
+        "node_modules/multimatch": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
+            "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/murmurhash3js-revisited": {
             "version": "3.0.0",
@@ -8711,6 +9224,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8865,9 +9388,10 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -8980,6 +9504,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/please-upgrade-node": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+            "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver-compare": "^1.0.0"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -8987,6 +9521,35 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+            "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/postgrator": {
@@ -9499,6 +10062,13 @@
                 "node": ">=8.6.0"
             }
         },
+        "node_modules/require-package-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+            "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/resolve": {
             "version": "1.22.4",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
@@ -9536,6 +10106,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/resolve-from": {
@@ -9773,6 +10357,13 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -9890,6 +10481,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/sparse-array": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
@@ -9938,6 +10539,13 @@
             "engines": {
                 "node": ">= 10.x"
             }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/standard": {
             "version": "17.1.2",
@@ -10321,14 +10929,6 @@
             },
             "engines": {
                 "node": ">=0.6.0"
-            }
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {
@@ -10944,6 +11544,16 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     },
     "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/pg": "^8.11.11",
         "depcheck": "^1.4.7",
         "dotenv": "^16.4.7",
         "mocha": "^11.1.0",
@@ -36,7 +35,6 @@
         "debug": "^4.4.0",
         "drand-client": "^1.2.6",
         "ethers": "^6.13.5",
-        "ipfs-car": "^2.0.0",
         "ipfs-unixfs-exporter": "^13.6.1",
         "just-percentile": "^4.2.0",
         "k-closest": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
         "test:lint": "standard",
         "test:unit": "mocha",
         "test:types": "tsc -p .",
-        "release": "np"
+        "release": "np",
+        "check-deps": "depcheck"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/pg": "^8.11.11",
+        "depcheck": "^1.4.7",
         "dotenv": "^16.4.7",
         "mocha": "^11.1.0",
         "np": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test:unit": "mocha",
         "test:types": "tsc -p .",
         "release": "np",
-        "check-deps": "depcheck"
+        "test:deps": "depcheck"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "migrate": "node bin/migrate.js",
         "start": "node bin/spark-evaluate.js",
-        "test": "npm run test:types && npm run test:lint && npm run test:unit",
+        "test": "npm run test:types && npm run test:lint && npm run test:unit && npm run test:deps",
         "test:lint": "standard",
         "test:unit": "mocha",
         "test:types": "tsc -p .",


### PR DESCRIPTION
Partially Fixes: https://github.com/CheckerNetwork/roadmap/issues/221

I have integrated `depcheck` into the project to detect unused dependencies. Additionally, I have added a configuration file to exclude `@Types`, `TypeScript`, and `depcheck` from the analysis, as these may produce false positives.