### PR TITLE
Add include minority results in evaluate script output. Closes #458

### DIFF
--- a/bin/evaluate-measurements.js
+++ b/bin/evaluate-measurements.js
@@ -42,7 +42,7 @@ const EVALUATION_NDJSON_FILE = `${basename(measurementsPath, '.ndjson')}.evaluat
 const evaluationTxtWriter = fs.createWriteStream(EVALUATION_TXT_FILE)
 const evaluationNdjsonWriter = fs.createWriteStream(EVALUATION_NDJSON_FILE)
 
-evaluationTxtWriter.write(formatHeader({ includeEvaluation: keepRejected }) + '\n')
+evaluationTxtWriter.write(formatHeader({ keepRejected }) + '\n')
 
 const resultCounts = {
   total: 0
@@ -97,27 +97,23 @@ async function processRound (roundIndex, measurements, resultCounts) {
     prepareProviderRetrievalResultStats: async () => {}
   })
 
-  for (const m of round.measurements) {
-    // FIXME: we should include non-majority measurements too
-    // See https://github.com/filecoin-station/spark-evaluate/pull/396
-    if (m.taskingEvaluation !== 'OK' && m.consensusEvaluation === 'MAJORITY_RESULT') continue
-    resultCounts.total++
-    resultCounts[m.retrievalResult] = (resultCounts[m.retrievalResult] ?? 0) + 1
+  if (!keepRejected) {
+    round.measurements = round.measurements.filter(m => m.taskingEvaluation === 'OK')
   }
 
-  if (!keepRejected) {
-    round.measurements = round.measurements
-      // Keep accepted measurements only
-      // FIXME: we should include non-majority measurements too
-      // See https://github.com/filecoin-station/spark-evaluate/pull/396
-      .filter(m => m.taskingEvaluation === 'OK' && m.consensusEvaluation === 'MAJORITY_RESULT')
-      // Remove the taskingEvaluation and consensusEvaluation fields as all accepted measurements have the same value
-      .map(m => ({ ...m, taskingEvaluation: undefined, majorityEvaluation: undefined }))
+  for (const m of round.measurements) {
+    resultCounts.total++
+    const status = m.taskingEvaluation !== 'OK'
+      ? m.taskingEvaluation
+      : m.consensusEvaluation !== 'MAJORITY_RESULT'
+        ? m.consensusEvaluation
+        : m.retrievalResult
+    resultCounts[status] = (resultCounts[status] ?? 0) + 1
   }
 
   evaluationTxtWriter.write(
     round.measurements
-      .map(m => formatMeasurement(m, { includeEvaluation: keepRejected }) + '\n')
+      .map(m => formatMeasurement(m, { keepRejected }) + '\n')
       .join('')
   )
   evaluationNdjsonWriter.write(
@@ -148,21 +144,20 @@ function isFlagEnabled (envVarValue) {
 /**
  * @param {import('../lib/preprocess.js').Measurement} m
  * @param {object} options
- * @param {boolean} [options.includeEvaluation]
+ * @param {boolean} [options.keepRejected]
  */
-function formatMeasurement (m, { includeEvaluation } = {}) {
+function formatMeasurement (m, { keepRejected } = {}) {
   const fields = [
     new Date(m.finished_at).toISOString(),
     (m.cid ?? '').padEnd(70),
     (m.protocol ?? '').padEnd(10)
   ]
 
-  if (includeEvaluation) {
-    // FIXME: we should distinguish tasking and majority evaluation
-    // See https://github.com/filecoin-station/spark-evaluate/pull/396
-    fields.push((m.taskingEvaluation === 'OK' && m.consensusEvaluation === 'MAJORITY_RESULT' ? '🫡  ' : '🙅  '))
+  if (keepRejected) {
+    fields.push((m.taskingEvaluation === 'OK' ? '🫡' : '🙅').padEnd(7))
   }
 
+  fields.push((m.consensusEvaluation === 'MAJORITY_RESULT' ? '🫡' : '🙅').padEnd(9))
   fields.push((m.retrievalResult ?? ''))
 
   return fields.join(' ')
@@ -170,19 +165,20 @@ function formatMeasurement (m, { includeEvaluation } = {}) {
 
 /**
  * @param {object} options
- * @param {boolean} [options.includeEvaluation]
+ * @param {boolean} [options.keepRejected]
  */
-function formatHeader ({ includeEvaluation } = {}) {
+function formatHeader ({ keepRejected } = {}) {
   const fields = [
     'Timestamp'.padEnd(new Date().toISOString().length),
     'CID'.padEnd(70),
     'Protocol'.padEnd(10)
   ]
 
-  if (includeEvaluation) {
-    fields.push('🕵️  ')
+  if (keepRejected) {
+    fields.push('Tasking')
   }
 
+  fields.push('Consensus')
   fields.push('RetrievalResult')
 
   return fields.join(' ')


### PR DESCRIPTION
Closes #458

# Before

```console
$ node bin/evaluate-measurements.js measurements-f010479.ndjson
[...]
Found 484 accepted measurements.
  OK                                       480        (99.17%)
  TIMEOUT                                  1          (0.2%)
  HOSTNAME_DNS_ERROR                       2          (0.41%)
  IPNI_ERROR_FETCH                         1          (0.2%)
[...]
```

☝️ Notice how minority results are included in the output, although they aren't actionable for the SP.

```console
$ head -n2 measurements-f010479.evaluation.txt
Timestamp                CID                                                                    Protocol   RetrievalResult
2025-02-16T20:22:15.307Z bafybeibhg66222vgfas5yc72hpnnydglezznfwjjwcgro6jgnj2st5ydi4            http       OK
```

☝️ Here there's no notion of whether something is a minority result or not.

```console
$ KEEP_REJECTED=1 node bin/evaluate-measurements.js measurements-f010479.ndjson
[...]
Found 484 accepted measurements.
  OK                                       480        (99.17%)
  TIMEOUT                                  1          (0.2%)
  HOSTNAME_DNS_ERROR                       2          (0.41%)
  IPNI_ERROR_FETCH                         1          (0.2%)
[...]
```

☝️ Same problem as above

```console
$ head -n2 measurements-f010479.evaluation.txt
Timestamp                CID                                                                    Protocol   🕵️   RetrievalResult
2025-02-16T20:22:15.307Z bafybeibhg66222vgfas5yc72hpnnydglezznfwjjwcgro6jgnj2st5ydi4            http       🫡   OK
```

☝️ It's not clear what 🕵️ means.

# After

```console
$ node bin/evaluate-measurements.js measurements-f010479.ndjson
Found 433 accepted measurements.
  OK                                       429        (99.07%)
  MINORITY_RESULT                          4          (0.92%)
```

☝️ See how the output has improved, and unactionable minority results are grouped in one row. Measurements that don't pass the tasking algorithm aren't included. Based on the above, the SP should have 100% RSR for the measurements tested. 

@bajtos should we exclude `MINORITY_RESULT` here and just say OK 100%?

```console
$ head -n2 measurements-f010479.evaluation.txt
Timestamp                CID                                                                    Protocol   Consensus RetrievalResult
2025-02-16T20:22:15.307Z bafybeibhg66222vgfas5yc72hpnnydglezznfwjjwcgro6jgnj2st5ydi4            http       🫡        OK
```

Notice new "Consensus" field. Measurements that don't pass the tasking algorithm aren't included.

```console
$ KEEP_REJECTED=1 node bin/evaluate-measurements.js measurements-f010479.ndjson
[...]
Found 484 accepted measurements.
  OK                                       429        (88.63%)
  TASK_WRONG_NODE                          23         (4.75%)
  MINORITY_RESULT                          4          (0.82%)
  DUP_INET_GROUP                           27         (5.57%)
  TASK_NOT_IN_ROUND                        1          (0.2%)
[...]
```

☝️ 👇  These now includes codes for everything: retrieval result, tasking failure and consensus failure.

```console
$ head -n2 measurements-f010479.evaluation.txt
Timestamp                CID                                                                    Protocol   Tasking Consensus RetrievalResult
2025-02-16T20:22:15.307Z bafybeibhg66222vgfas5yc72hpnnydglezznfwjjwcgro6jgnj2st5ydi4            http       🫡      🫡        OK
```