### PR TITLE
fix: accept Graphsync measurements without HEAD status

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -268,7 +268,14 @@ export const assertValidMeasurement = measurement => {
     assert(measurement.end_at >= measurement.first_byte_at, 'end_at must be greater than or equal to first_byte_at')
     assert(measurement.first_byte_at >= measurement.start_at, 'first_byte_at must be greater than or equal to start_at')
 
-    assert.strictEqual(typeof measurement.head_status_code, 'number', '`head_status_code` must be a number')
+    if (measurement.protocol === 'http') {
+      assert.strictEqual(typeof measurement.head_status_code, 'number', '`head_status_code` must be a number')
+    } else {
+      assert(
+        measurement.head_status_code === undefined || measurement.head_status_code === null,
+        '`head_status_code` must be undefined or null for non-HTTP retrievals'
+      )
+    }
   }
 }
 

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -314,6 +314,7 @@ describe('assertValidMeasurement', () => {
     assert.throws(
       () => assertValidMeasurement({
         ...VALID_MEASUREMENT,
+        protocol: 'http',
         head_status_code: null
       }),
       /`head_status_code` must be a number/
@@ -321,9 +322,37 @@ describe('assertValidMeasurement', () => {
     assert.throws(
       () => assertValidMeasurement({
         ...VALID_MEASUREMENT,
+        protocol: 'http',
         head_status_code: /** @type {any} */ ('200')
       }),
       /`head_status_code` must be a number/
+    )
+  })
+
+  it('accepts Graphsync measurements with OK retrieval result and head_status_code is null', () => {
+    assertValidMeasurement({
+      ...VALID_MEASUREMENT,
+      protocol: 'graphsync',
+      head_status_code: null
+
+    })
+  })
+
+  it('accepts Graphsync measurements with OK retrieval result and head_status_code is undefined', () => {
+    assertValidMeasurement({
+      ...VALID_MEASUREMENT,
+      protocol: 'graphsync',
+      head_status_code: undefined
+    })
+  })
+
+  it('rejects Graphsync measurements with head_status_code not null/undefined ', () => {
+    assert.throws(
+      () => assertValidMeasurement({
+        ...VALID_MEASUREMENT,
+        head_status_code: /** @type {any} */ ('200')
+      }),
+      /`head_status_code` must be undefined/
     )
   })
 


### PR DESCRIPTION
Fix the regression introduced by e2a458b (#475)

- Graphsync retrievals don't test HEAD request, see https://github.com/CheckerNetwork/spark-checker/commit/3f8edc5539ddf83f8cb2cc1ccdd534a7a1624f1f
- As a result, measurements for Graphsync retrievals have `head_status_code` set to undefined or null.
- The validation performed during the preprocessing step discarded such measurements as invalid.

This pull requests relaxes the validation during preprocessing to assert numeric `head_status_code` for HTTP retrievals only.