### PR TITLE
fix: exlude IPNI_ERROR_5xx measurements from RSR

### DIFF
--- a/lib/provider-retrieval-result-stats.js
+++ b/lib/provider-retrieval-result-stats.js
@@ -21,6 +21,9 @@ export const build = committees => {
   for (const c of committees) {
     // IMPORTANT: include minority results in the calculation
     for (const m of c.measurements) {
+      // Ignore measurements reporting IPNI service outage
+      if (m.retrievalResult.match(/^IPNI_ERROR_5\d\d$/)) continue
+
       const minerId = m.minerId
       const retrievalStats = providerRetrievalResultStats.get(minerId) ?? { total: 0, successful: 0, successfulHttp: 0, successfulHttpHead: 0 }
       retrievalStats.total++

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -390,6 +390,9 @@ function buildPerPartyStats (committees, perDealParty, partyName) {
     }
     const retrievalStats = retrievalStatsPerParty.get(partyId)
     for (const m of measurements) {
+      // Ignore measurements reporting IPNI service outage
+      if (m.retrievalResult.match(/^IPNI_ERROR_5\d\d$/)) continue
+
       retrievalStats.total++
       if (m.retrievalResult === 'OK') {
         retrievalStats.successful++

--- a/test/public-stats.test.js
+++ b/test/public-stats.test.js
@@ -648,237 +648,240 @@ describe('public-stats', () => {
         { day: today, miner_id: 'f1second', ttfb_p50: [1500] }
       ])
     })
+  })
 
-    describe('updateDailyClientRetrievalStats', () => {
-      it('aggregates per client stats', async () => {
-        // We create multiple measurements with different miner ids and thus key ids
-        // We also want to test multiple different number of measurements for a given combination of (cid,minerId)
-        /** @type {Measurement[]} */
-        const allMeasurements = [
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+  describe('updateDailyClientRetrievalStats', () => {
+    it('aggregates per client stats', async () => {
+      // We create multiple measurements with different miner ids and thus key ids
+      // We also want to test multiple different number of measurements for a given combination of (cid,minerId)
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
 
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
-        ]
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
+      ]
 
-        // Separate the measurements into two groups, one for the client f0 and the other for f1
-        const findDealClients = (minerId, _cid) => {
-          switch (minerId) {
-            case 'f0test':
-              return ['f0client']
-            case 'f1test':
-              return ['f1client']
-            default:
-              throw new Error('Unexpected minerId')
-          }
+      // Separate the measurements into two groups, one for the client f0 and the other for f1
+      const findDealClients = (minerId, _cid) => {
+        switch (minerId) {
+          case 'f0test':
+            return ['f0client']
+          case 'f1test':
+            return ['f1client']
+          default:
+            throw new Error('Unexpected minerId')
         }
-        const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-        const { rows: created } = await pgClient.query(
-          'SELECT * FROM daily_client_retrieval_stats'
-        )
-        assert.deepStrictEqual(created, [])
-        await updateDailyClientRetrievalStats(
-          pgClient,
-          committees,
-          findDealClients
-        )
-        const { rows } = await pgClient.query(
-          `SELECT 
-               day::TEXT, 
-               client_id, 
-               total, 
-               successful, 
-               successful_http 
-            FROM daily_client_retrieval_stats 
+      }
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      const { rows: created } = await pgClient.query(
+        'SELECT * FROM daily_client_retrieval_stats'
+      )
+      assert.deepStrictEqual(created, [])
+      await updateDailyClientRetrievalStats(
+        pgClient,
+        committees,
+        findDealClients
+      )
+      const { rows } = await pgClient.query(
+          `SELECT
+               day::TEXT,
+               client_id,
+               total,
+               successful,
+               successful_http
+            FROM daily_client_retrieval_stats
             ORDER BY client_id`)
 
-        assert.deepStrictEqual(rows, [
-          { day: today, client_id: 'f0client', total: 2, successful: 2, successful_http: 2 },
-          { day: today, client_id: 'f1client', total: 3, successful: 3, successful_http: 3 }
-        ])
-      })
-      it('aggregates overlapping per client stats', async () => {
-        /** @type {Measurement[]} */
-        const allMeasurements = [
-          // minerId f01test stores deals for both client f0 and f1
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
+      assert.deepStrictEqual(rows, [
+        { day: today, client_id: 'f0client', total: 2, successful: 2, successful_http: 2 },
+        { day: today, client_id: 'f1client', total: 3, successful: 3, successful_http: 3 }
+      ])
+    })
+    it('aggregates overlapping per client stats', async () => {
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        // minerId f01test stores deals for both client f0 and f1
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
 
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
-        ]
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
+      ]
 
-        // Separate the measurements into two groups, one for the client f0 and f1 and the other only for f1
-        const findDealClients = (minerId, cid) => {
-          // Check that the CID is passed correctly
-          assert.strictEqual(cid, VALID_MEASUREMENT.cid)
-          switch (minerId) {
-            case 'f01test':
-              return ['f0client', 'f1client']
-            case 'f1test':
-              return ['f1client']
-            default:
-              throw new Error('Unexpected minerId')
-          }
+      // Separate the measurements into two groups, one for the client f0 and f1 and the other only for f1
+      const findDealClients = (minerId, cid) => {
+        // Check that the CID is passed correctly
+        assert.strictEqual(cid, VALID_MEASUREMENT.cid)
+        switch (minerId) {
+          case 'f01test':
+            return ['f0client', 'f1client']
+          case 'f1test':
+            return ['f1client']
+          default:
+            throw new Error('Unexpected minerId')
         }
-        const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-        await updateDailyClientRetrievalStats(
-          pgClient,
-          committees,
-          findDealClients
-        )
-        const { rows } = await pgClient.query(
-          `SELECT 
-               day::TEXT, 
-               client_id, 
-               total, 
-               successful, 
-               successful_http 
-            FROM daily_client_retrieval_stats 
+      }
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyClientRetrievalStats(
+        pgClient,
+        committees,
+        findDealClients
+      )
+      const { rows } = await pgClient.query(
+          `SELECT
+               day::TEXT,
+               client_id,
+               total,
+               successful,
+               successful_http
+            FROM daily_client_retrieval_stats
             ORDER BY client_id`)
 
-        assert.deepStrictEqual(rows, [
-          { day: today, client_id: 'f0client', total: 2, successful: 2, successful_http: 2 },
-          { day: today, client_id: 'f1client', total: 5, successful: 5, successful_http: 5 }
-        ])
-      })
-      it('skips clients that have not match for a given miner_id,piece_cid combination', async () => {
-        /** @type {Measurement[]} */
-        const allMeasurements = [
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
-        ]
+      assert.deepStrictEqual(rows, [
+        { day: today, client_id: 'f0client', total: 2, successful: 2, successful_http: 2 },
+        { day: today, client_id: 'f1client', total: 5, successful: 5, successful_http: 5 }
+      ])
+    })
+    it('skips clients that have not match for a given miner_id,piece_cid combination', async () => {
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
+      ]
 
-        const findDealClients = (_minerId, _cid) => undefined
+      const findDealClients = (_minerId, _cid) => undefined
 
-        const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-        // We test the warning output by changing the default warn function
-        const originalWarn = console.warn
-        let warnCalled = false
-        console.warn = function (message) {
-          warnCalled = true
-          assert(message.includes('no deal clients found. Excluding the task from daily per-client stats.'))
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      // We test the warning output by changing the default warn function
+      const originalWarn = console.warn
+      let warnCalled = false
+      console.warn = function (message) {
+        warnCalled = true
+        assert(message.includes('no deal clients found. Excluding the task from daily per-client stats.'))
+      }
+      await updateDailyClientRetrievalStats(
+        pgClient,
+        committees,
+        findDealClients
+      )
+      // Reset warning function
+      console.warn = originalWarn
+
+      // Warning function should have been called
+      assert(warnCalled)
+      const { rows: stats } = await pgClient.query(
+        'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
+      )
+      assert.strictEqual(stats.length, 0, `No stats should be recorded: ${JSON.stringify(stats)}`)
+    })
+    it('updates existing clients rsr scores on conflicting client_id,day pairs', async () => {
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
+      ]
+
+      const findDealClients = (_minerId, _cid) => ['f0client']
+
+      let committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyClientRetrievalStats(
+        pgClient,
+        committees,
+        findDealClients
+      )
+      let { rows: stats } = await pgClient.query(
+        'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
+      )
+      assert.strictEqual(stats.length, 1)
+      assert.deepStrictEqual(stats, [
+        { day: today, client_id: 'f0client', total: 1, successful: 1, successful_http: 1 }
+      ])
+
+      // We now create another round of measurements for the same client and day
+      allMeasurements.push(
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
+      )
+      committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyClientRetrievalStats(
+        pgClient,
+        committees,
+        findDealClients
+      )
+      stats = (await pgClient.query(
+        'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
+      )).rows
+      assert.strictEqual(stats.length, 1)
+      assert.deepStrictEqual(stats, [
+        { day: today, client_id: 'f0client', total: 4, successful: 4, successful_http: 4 }
+      ])
+    })
+    it('correctly handles different protocols and retrieval results', async () => {
+      // We create multiple measurements that have different combinations of protocols and retrieval results
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'NOT_HTTP', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test', retrievalResult: 'HTTP_404' }
+      ]
+      const findDealClients = (_minerId, _cid) => ['f0client']
+
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyClientRetrievalStats(
+        pgClient,
+        committees,
+        findDealClients
+      )
+      const { rows: stats } = await pgClient.query(
+        'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
+      )
+      // Http protocols should be counted as successful and successful_http while other protocols should only be counted as successful
+      // Measurements with retrievalResult HTTP_404 should only be counted to the total number of results
+      assert.deepStrictEqual(stats, [
+        { day: today, client_id: 'f0client', total: 3, successful: 2, successful_http: 1 }
+      ])
+    })
+  })
+
+  describe('updateDailyAllocatorRetrievalStats', () => {
+    it('aggregates per allocator stats', async () => {
+      // We create multiple measurements with different miner ids and thus key ids
+      // We also want to test multiple different number of measurements for a given combination of (cid,minerId)
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
+      ]
+
+      // Separate the measurements into two groups, one for the allocator f0 and the other for f1
+      const findDealAllocators = (minerId, _cid) => {
+        switch (minerId) {
+          case 'f0test':
+            return ['f0allocator']
+          case 'f1test':
+            return ['f1allocator']
+          default:
+            throw new Error('Unexpected minerId')
         }
-        await updateDailyClientRetrievalStats(
-          pgClient,
-          committees,
-          findDealClients
-        )
-        // Reset warning function
-        console.warn = originalWarn
-
-        // Warning function should have been called
-        assert(warnCalled)
-        const { rows: stats } = await pgClient.query(
-          'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
-        )
-        assert.strictEqual(stats.length, 0, `No stats should be recorded: ${JSON.stringify(stats)}`)
-      })
-      it('updates existing clients rsr scores on conflicting client_id,day pairs', async () => {
-        /** @type {Measurement[]} */
-        const allMeasurements = [
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
-        ]
-
-        const findDealClients = (_minerId, _cid) => ['f0client']
-
-        let committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-        await updateDailyClientRetrievalStats(
-          pgClient,
-          committees,
-          findDealClients
-        )
-        let { rows: stats } = await pgClient.query(
-          'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
-        )
-        assert.strictEqual(stats.length, 1)
-        assert.deepStrictEqual(stats, [
-          { day: today, client_id: 'f0client', total: 1, successful: 1, successful_http: 1 }
-        ])
-
-        // We now create another round of measurements for the same client and day
-        allMeasurements.push(
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
-        )
-        committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-        await updateDailyClientRetrievalStats(
-          pgClient,
-          committees,
-          findDealClients
-        )
-        stats = (await pgClient.query(
-          'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
-        )).rows
-        assert.strictEqual(stats.length, 1)
-        assert.deepStrictEqual(stats, [
-          { day: today, client_id: 'f0client', total: 4, successful: 4, successful_http: 4 }
-        ])
-      })
-      it('correctly handles different protocols and retrieval results', async () => {
-        // We create multiple measurements that have different combinations of protocols and retrieval results
-        /** @type {Measurement[]} */
-        const allMeasurements = [
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-          { ...VALID_MEASUREMENT, protocol: 'NOT_HTTP', minerId: 'f0test' },
-          { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test', retrievalResult: 'HTTP_404' }
-        ]
-        const findDealClients = (_minerId, _cid) => ['f0client']
-
-        const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-        await updateDailyClientRetrievalStats(
-          pgClient,
-          committees,
-          findDealClients
-        )
-        const { rows: stats } = await pgClient.query(
-          'SELECT day::TEXT,client_id,total,successful,successful_http FROM daily_client_retrieval_stats'
-        )
-        // Http protocols should be counted as successful and successful_http while other protocols should only be counted as successful
-        // Measurements with retrievalResult HTTP_404 should only be counted to the total number of results
-        assert.deepStrictEqual(stats, [
-          { day: today, client_id: 'f0client', total: 3, successful: 2, successful_http: 1 }
-        ])
-      })
-      describe('updateDailyAggregatorRetrievalStats', () => {
-        it('aggregates per aggregator stats', async () => {
-          // We create multiple measurements with different miner ids and thus key ids
-          // We also want to test multiple different number of measurements for a given combination of (cid,minerId)
-          /** @type {Measurement[]} */
-          const allMeasurements = [
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
-          ]
-
-          // Separate the measurements into two groups, one for the allocator f0 and the other for f1
-          const findDealAllocators = (minerId, _cid) => {
-            switch (minerId) {
-              case 'f0test':
-                return ['f0allocator']
-              case 'f1test':
-                return ['f1allocator']
-              default:
-                throw new Error('Unexpected minerId')
-            }
-          }
-          const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-          const { rows: created } = await pgClient.query(
-            'SELECT * FROM daily_allocator_retrieval_stats'
-          )
-          assert.deepStrictEqual(created, [])
-          await updateDailyAllocatorRetrievalStats(
-            pgClient,
-            committees,
-            findDealAllocators
-          )
-          const { rows } = await pgClient.query(
+      }
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      const { rows: created } = await pgClient.query(
+        'SELECT * FROM daily_allocator_retrieval_stats'
+      )
+      assert.deepStrictEqual(created, [])
+      await updateDailyAllocatorRetrievalStats(
+        pgClient,
+        committees,
+        findDealAllocators
+      )
+      const { rows } = await pgClient.query(
             `SELECT
                  day::TEXT,
                  allocator_id,
@@ -888,43 +891,43 @@ describe('public-stats', () => {
               FROM daily_allocator_retrieval_stats
               ORDER BY allocator_id`)
 
-          assert.deepStrictEqual(rows, [
-            { day: today, allocator_id: 'f0allocator', total: 2, successful: 2, successful_http: 2 },
-            { day: today, allocator_id: 'f1allocator', total: 3, successful: 3, successful_http: 3 }
-          ])
-        })
-        it('aggregates overlapping per allocator stats', async () => {
-          /** @type {Measurement[]} */
-          const allMeasurements = [
-            // minerId f01test stores deals for both allocator f0 and f1
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
+      assert.deepStrictEqual(rows, [
+        { day: today, allocator_id: 'f0allocator', total: 2, successful: 2, successful_http: 2 },
+        { day: today, allocator_id: 'f1allocator', total: 3, successful: 3, successful_http: 3 }
+      ])
+    })
+    it('aggregates overlapping per allocator stats', async () => {
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        // minerId f01test stores deals for both allocator f0 and f1
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f01test' },
 
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
-          ]
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
+      ]
 
-          // Separate the measurements into two groups, one for the allocator f0 and f1 and the other only for f1
-          const findDealAllocators = (minerId, cid) => {
-            // Check that the CID is passed correctly
-            assert.strictEqual(cid, VALID_MEASUREMENT.cid)
-            switch (minerId) {
-              case 'f01test':
-                return ['f0allocator', 'f1allocator']
-              case 'f1test':
-                return ['f1allocator']
-              default:
-                throw new Error('Unexpected minerId')
-            }
-          }
-          const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-          await updateDailyAllocatorRetrievalStats(
-            pgClient,
-            committees,
-            findDealAllocators
-          )
-          const { rows } = await pgClient.query(
+      // Separate the measurements into two groups, one for the allocator f0 and f1 and the other only for f1
+      const findDealAllocators = (minerId, cid) => {
+        // Check that the CID is passed correctly
+        assert.strictEqual(cid, VALID_MEASUREMENT.cid)
+        switch (minerId) {
+          case 'f01test':
+            return ['f0allocator', 'f1allocator']
+          case 'f1test':
+            return ['f1allocator']
+          default:
+            throw new Error('Unexpected minerId')
+        }
+      }
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyAllocatorRetrievalStats(
+        pgClient,
+        committees,
+        findDealAllocators
+      )
+      const { rows } = await pgClient.query(
             `SELECT
                  day::TEXT,
                  allocator_id,
@@ -934,110 +937,108 @@ describe('public-stats', () => {
               FROM daily_allocator_retrieval_stats
               ORDER BY allocator_id`)
 
-          assert.deepStrictEqual(rows, [
-            { day: today, allocator_id: 'f0allocator', total: 2, successful: 2, successful_http: 2 },
-            { day: today, allocator_id: 'f1allocator', total: 5, successful: 5, successful_http: 5 }
-          ])
-        })
-        it('skips allocators that have no match for a given miner_id,piece_cid combination', async () => {
-          /** @type {Measurement[]} */
-          const allMeasurements = [
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
-          ]
+      assert.deepStrictEqual(rows, [
+        { day: today, allocator_id: 'f0allocator', total: 2, successful: 2, successful_http: 2 },
+        { day: today, allocator_id: 'f1allocator', total: 5, successful: 5, successful_http: 5 }
+      ])
+    })
+    it('skips allocators that have no match for a given miner_id,piece_cid combination', async () => {
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f1test' }
+      ]
 
-          const findDealAllocators = (_minerId, _cid) => undefined
+      const findDealAllocators = (_minerId, _cid) => undefined
 
-          const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-          // We test the warning output by changing the default warn function
-          const originalWarn = console.warn
-          let warnCalled = false
-          console.warn = function (message) {
-            warnCalled = true
-            assert(message.includes('no deal allocators found. Excluding the task from daily per-allocator stats.'))
-          }
-          await updateDailyAllocatorRetrievalStats(
-            pgClient,
-            committees,
-            findDealAllocators
-          )
-          // Reset warning function
-          console.warn = originalWarn
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      // We test the warning output by changing the default warn function
+      const originalWarn = console.warn
+      let warnCalled = false
+      console.warn = function (message) {
+        warnCalled = true
+        assert(message.includes('no deal allocators found. Excluding the task from daily per-allocator stats.'))
+      }
+      await updateDailyAllocatorRetrievalStats(
+        pgClient,
+        committees,
+        findDealAllocators
+      )
+      // Reset warning function
+      console.warn = originalWarn
 
-          // Warning function should have been called
-          assert(warnCalled)
-          const { rows: stats } = await pgClient.query(
-            'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
-          )
-          assert.strictEqual(stats.length, 0, `No stats should be recorded: ${JSON.stringify(stats)}`)
-        })
-        it('updates existing allocators rsr scores on conflicting allocator_id,day pairs', async () => {
-          /** @type {Measurement[]} */
-          const allMeasurements = [
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
-          ]
+      // Warning function should have been called
+      assert(warnCalled)
+      const { rows: stats } = await pgClient.query(
+        'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
+      )
+      assert.strictEqual(stats.length, 0, `No stats should be recorded: ${JSON.stringify(stats)}`)
+    })
+    it('updates existing allocators rsr scores on conflicting allocator_id,day pairs', async () => {
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
+      ]
 
-          const findDealAllocators = (_minerId, _cid) => ['f0allocator']
+      const findDealAllocators = (_minerId, _cid) => ['f0allocator']
 
-          let committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-          await updateDailyAllocatorRetrievalStats(
-            pgClient,
-            committees,
-            findDealAllocators
-          )
-          let { rows: stats } = await pgClient.query(
-            'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
-          )
-          assert.strictEqual(stats.length, 1)
-          assert.deepStrictEqual(stats, [
-            { day: today, allocator_id: 'f0allocator', total: 1, successful: 1, successful_http: 1 }
-          ])
+      let committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyAllocatorRetrievalStats(
+        pgClient,
+        committees,
+        findDealAllocators
+      )
+      let { rows: stats } = await pgClient.query(
+        'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
+      )
+      assert.strictEqual(stats.length, 1)
+      assert.deepStrictEqual(stats, [
+        { day: today, allocator_id: 'f0allocator', total: 1, successful: 1, successful_http: 1 }
+      ])
 
-          // We now create another round of measurements for the same allocator and day
-          allMeasurements.push(
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
-          )
-          committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-          await updateDailyAllocatorRetrievalStats(
-            pgClient,
-            committees,
-            findDealAllocators
-          )
-          stats = (await pgClient.query(
-            'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
-          )).rows
-          assert.strictEqual(stats.length, 1)
-          assert.deepStrictEqual(stats, [
-            { day: today, allocator_id: 'f0allocator', total: 4, successful: 4, successful_http: 4 }
-          ])
-        })
-        it('correctly handles different protocols and retrieval results', async () => {
-          // We create multiple measurements that have different combinations of protocols and retrieval results
-          /** @type {Measurement[]} */
-          const allMeasurements = [
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
-            { ...VALID_MEASUREMENT, protocol: 'NOT_HTTP', minerId: 'f0test' },
-            { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test', retrievalResult: 'HTTP_404' }
-          ]
-          const findDealAllocators = (_minerId, _cid) => ['f0allocator']
+      // We now create another round of measurements for the same allocator and day
+      allMeasurements.push(
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' }
+      )
+      committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyAllocatorRetrievalStats(
+        pgClient,
+        committees,
+        findDealAllocators
+      )
+      stats = (await pgClient.query(
+        'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
+      )).rows
+      assert.strictEqual(stats.length, 1)
+      assert.deepStrictEqual(stats, [
+        { day: today, allocator_id: 'f0allocator', total: 4, successful: 4, successful_http: 4 }
+      ])
+    })
+    it('correctly handles different protocols and retrieval results', async () => {
+      // We create multiple measurements that have different combinations of protocols and retrieval results
+      /** @type {Measurement[]} */
+      const allMeasurements = [
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'NOT_HTTP', minerId: 'f0test' },
+        { ...VALID_MEASUREMENT, protocol: 'http', minerId: 'f0test', retrievalResult: 'HTTP_404' }
+      ]
+      const findDealAllocators = (_minerId, _cid) => ['f0allocator']
 
-          const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
-          await updateDailyAllocatorRetrievalStats(
-            pgClient,
-            committees,
-            findDealAllocators
-          )
-          const { rows: stats } = await pgClient.query(
-            'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
-          )
-          // Http protocols should be counted as successful and successful_http while other protocols should only be counted as successful
-          // Measurements with retrievalResult HTTP_404 should only be counted to the total number of results
-          assert.deepStrictEqual(stats, [
-            { day: today, allocator_id: 'f0allocator', total: 3, successful: 2, successful_http: 1 }
-          ])
-        })
-      })
+      const committees = buildEvaluatedCommitteesFromMeasurements(allMeasurements)
+      await updateDailyAllocatorRetrievalStats(
+        pgClient,
+        committees,
+        findDealAllocators
+      )
+      const { rows: stats } = await pgClient.query(
+        'SELECT day::TEXT,allocator_id,total,successful,successful_http FROM daily_allocator_retrieval_stats'
+      )
+      // Http protocols should be counted as successful and successful_http while other protocols should only be counted as successful
+      // Measurements with retrievalResult HTTP_404 should only be counted to the total number of results
+      assert.deepStrictEqual(stats, [
+        { day: today, allocator_id: 'f0allocator', total: 3, successful: 2, successful_http: 1 }
+      ])
     })
   })
 


### PR DESCRIPTION
This PR has two commits to make the review easier:
- **refactor: fix test structure and names**
- **feat: exlude `IPNI_ERROR_5xx` measurements from RSR**

Links:
- https://github.com/CheckerNetwork/roadmap/issues/256

**feat: exlude `IPNI_ERROR_5xx` measurements from RSR**

Degradation of the IPNI service at cid.contact should not affect retrieval success rates.

This change is modifying the RSR calculations to exclude measurements with retrieval status `IPNI_ERROR_5xx` (e.g. `IPNI_ERROR_504`).

Important: we keep including `IPNI_ERROR_5xx` measurements in all other places. Most notably:

- Committees includes `IPNI_ERROR_5xx` measurements when looking for a majority consensus. This is important for the security of the protocol. If we excluded `IPNI_ERROR_5xx`s from the committee, then it would be easier for a malicious node to control the majority during IPNI outages, since the committees would be much smaller.

- RSR breakdowns submitted to InfluxDB and rendered in the Spark Internal Dashboard include `IPNI_ERROR_5xx` measurements. This is important to give us visibility into the data reported by the network.

- The RSR breakdown shown in the Spark public dashboard is based on the RSR breakdowns in InfluxDB, therefore it will show `IPNI_ERROR_5xx` as well.

**refactor: fix test structure and names**

I noticed that the tests for per-client and per-allocator RSRs are incorrectly nested inside a `describe()` block for a different feature.

I also noticed one test name refers to "aggregators" instead of "allocators".

This commit is fixing both problems.

The change is best reviewed in a diff ignoring white-space changes.
