### PR TITLE
fix: exclude IPNI 5xx from "success rate" in Influx

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -59,6 +59,7 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   const durationValues = []
   const sizeValues = []
   let httpSuccesses = 0
+  let indexerServerErrorCount = 0
 
   for (const m of measurements) {
     // `retrievalResult` should be always set by lib/preprocess.js, so we should never encounter
@@ -104,9 +105,16 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
 
     // A successful HTTP response is a response with result breakdown set to OK and the protocol being used is set to HTTP.
     if (m.retrievalResult === 'OK' && m.protocol === 'http') { httpSuccesses++ }
+
+    if (m.retrievalResult.match(/^IPNI_ERROR_5\d\d$/)) {
+      indexerServerErrorCount++
+    }
   }
-  const successRate = resultBreakdown.OK / totalCount
-  const successRateHttp = httpSuccesses / totalCount
+
+  const totalForRSR = totalCount - indexerServerErrorCount
+  const successRate = totalForRSR ? resultBreakdown.OK / (totalCount - indexerServerErrorCount) : 0
+  const successRateHttp = totalForRSR ? httpSuccesses / (totalCount - indexerServerErrorCount) : 1
+  telemetryPoint.intField('total_for_success_rates', totalForRSR)
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)
   telemetryPoint.floatField('success_rate_http', successRateHttp)

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -113,7 +113,7 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
 
   const totalForRSR = totalCount - indexerServerErrorCount
   const successRate = totalForRSR ? resultBreakdown.OK / (totalCount - indexerServerErrorCount) : 0
-  const successRateHttp = totalForRSR ? httpSuccesses / (totalCount - indexerServerErrorCount) : 1
+  const successRateHttp = totalForRSR ? httpSuccesses / (totalCount - indexerServerErrorCount) : 0
   telemetryPoint.intField('total_for_success_rates', totalForRSR)
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -112,8 +112,8 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   }
 
   const totalForRSR = totalCount - indexerServerErrorCount
-  const successRate = totalForRSR ? resultBreakdown.OK / (totalCount - indexerServerErrorCount) : 0
-  const successRateHttp = totalForRSR ? httpSuccesses / (totalCount - indexerServerErrorCount) : 0
+  const successRate = totalForRSR ? resultBreakdown.OK / totalForRSR : 0
+  const successRateHttp = totalForRSR ? httpSuccesses / totalForRSR : 0
   telemetryPoint.intField('total_for_success_rates', totalForRSR)
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -136,10 +136,12 @@ describe('retrieval statistics', () => {
     /** @type {Measurement[]} */
     const measurements = [
       {
-        ...VALID_MEASUREMENT
+        ...VALID_MEASUREMENT,
+        protocol: 'http'
       },
       {
         ...VALID_MEASUREMENT,
+        protocol: 'http',
         retrievalResult: 'IPNI_ERROR_504',
         indexerResult: 'ERROR_504'
       }
@@ -152,6 +154,7 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'measurements', '2i')
     assertPointFieldValue(point, 'total_for_success_rates', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
+    assertPointFieldValue(point, 'success_rate_http', '1')
   })
 
   it('handles when all measurements reported IPNI 5xx', async () => {
@@ -171,6 +174,7 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'measurements', '1i')
     assertPointFieldValue(point, 'total_for_success_rates', '0i')
     assertPointFieldValue(point, 'success_rate', '0')
+    assertPointFieldValue(point, 'success_rate_http', '0')
   })
 
   it('handles first_byte_at set to unix epoch', () => {

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -106,6 +106,73 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'rate_of_deals_advertising_http', '0.5')
   })
 
+  it('includes IPNI 5xx errors in breakdowns', async () => {
+    /** @type {Measurement[]} */
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT
+      },
+      {
+        ...VALID_MEASUREMENT,
+        retrievalResult: 'IPNI_ERROR_504',
+        indexerResult: 'ERROR_504'
+      }
+    ]
+
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+
+    assertPointFieldValue(point, 'measurements', '2i')
+
+    assertPointFieldValue(point, 'result_rate_OK', '0.5')
+    assertPointFieldValue(point, 'result_rate_IPNI_ERROR_504', '0.5')
+
+    assertPointFieldValue(point, 'indexer_rate_OK', '0.5')
+    assertPointFieldValue(point, 'indexer_rate_ERROR_504', '0.5')
+  })
+
+  it('excludes IPNI 5xx errors from success rates', async () => {
+    /** @type {Measurement[]} */
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT
+      },
+      {
+        ...VALID_MEASUREMENT,
+        retrievalResult: 'IPNI_ERROR_504',
+        indexerResult: 'ERROR_504'
+      }
+    ]
+
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+
+    assertPointFieldValue(point, 'measurements', '2i')
+    assertPointFieldValue(point, 'total_for_success_rates', '1i')
+    assertPointFieldValue(point, 'success_rate', '1')
+  })
+
+  it('handles when all measurements reported IPNI 5xx', async () => {
+    /** @type {Measurement[]} */
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT,
+        retrievalResult: 'IPNI_ERROR_504',
+        indexerResult: 'ERROR_504'
+      }
+    ]
+
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+
+    assertPointFieldValue(point, 'measurements', '1i')
+    assertPointFieldValue(point, 'total_for_success_rates', '0i')
+    assertPointFieldValue(point, 'success_rate', '0')
+  })
+
   it('handles first_byte_at set to unix epoch', () => {
     const measurements = [
       {


### PR DESCRIPTION
In the previous change (#512), I modified the code writing RSR to the database for spark-stats to exclude IPNI 5xx results from the calculation.

We need to apply the same change to RSR written to InfluxDB.
- We want the RSR in our internal dashboard to be consistent with the RSR in the public dashboard.
- I want to create an alert to let us know when the RSR unexpectedly drops. That alert must not be triggered by IPNI service degradations.

Note: I still want the result breakdowns to include IPNI 5xx errors.  I added a test to capture that requirement.

Links:
- https://github.com/CheckerNetwork/roadmap/issues/252
