### PR TITLE
feat: include minority results in telemetry stats

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -65,9 +65,6 @@ export const evaluate = async ({
   const measurementsToReward = measurements.filter(
     m => m.taskingEvaluation === 'OK' && m.consensusEvaluation === 'MAJORITY_RESULT'
   )
-  const validMinorityResults = measurements.filter(
-    m => m.taskingEvaluation === 'OK' && m.consensusEvaluation === 'MINORITY_RESULT'
-  )
 
   // Calculate reward shares
   const participants = {}
@@ -156,12 +153,13 @@ export const evaluate = async ({
   })
 
   const ignoredErrors = []
-
+  const honestMeasurements = measurements.filter(
+    m => m.taskingEvaluation === 'OK' && (m.consensusEvaluation === 'MINORITY_RESULT' || m.consensusEvaluation === 'MAJORITY_RESULT')
+  )
   try {
     recordTelemetry('retrieval_stats_honest', (point) => {
       point.intField('round_index', roundIndex)
-      buildRetrievalStats(measurementsToReward, point)
-      buildRetrievalStats(validMinorityResults, point)
+      buildRetrievalStats(honestMeasurements, point)
     })
   } catch (err) {
     console.error('Cannot record retrieval stats (honest).', err)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -154,7 +154,7 @@ export const evaluate = async ({
 
   const ignoredErrors = []
   const honestMeasurements = measurements.filter(
-    m => m.taskingEvaluation === 'OK' && (m.consensusEvaluation === 'MINORITY_RESULT' || m.consensusEvaluation === 'MAJORITY_RESULT')
+    m => m.taskingEvaluation === 'OK'
   )
   try {
     recordTelemetry('retrieval_stats_honest', (point) => {

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -65,6 +65,9 @@ export const evaluate = async ({
   const measurementsToReward = measurements.filter(
     m => m.taskingEvaluation === 'OK' && m.consensusEvaluation === 'MAJORITY_RESULT'
   )
+  const validMinorityResults = measurements.filter(
+    m => m.taskingEvaluation === 'OK' && m.consensusEvaluation === 'MINORITY_RESULT'
+  )
 
   // Calculate reward shares
   const participants = {}
@@ -157,9 +160,8 @@ export const evaluate = async ({
   try {
     recordTelemetry('retrieval_stats_honest', (point) => {
       point.intField('round_index', roundIndex)
-      // FIXME: Include non-majority measurements in these stats
-      // See https://github.com/filecoin-station/spark-evaluate/issues/446
       buildRetrievalStats(measurementsToReward, point)
+      buildRetrievalStats(validMinorityResults, point)
     })
   } catch (err) {
     console.error('Cannot record retrieval stats (honest).', err)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -153,13 +153,13 @@ export const evaluate = async ({
   })
 
   const ignoredErrors = []
-  const honestMeasurements = measurements.filter(
+  const approvedMeasurements = measurements.filter(
     m => m.taskingEvaluation === 'OK'
   )
   try {
     recordTelemetry('retrieval_stats_honest', (point) => {
       point.intField('round_index', roundIndex)
-      buildRetrievalStats(honestMeasurements, point)
+      buildRetrievalStats(approvedMeasurements, point)
     })
   } catch (err) {
     console.error('Cannot record retrieval stats (honest).', err)

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -324,6 +324,58 @@ describe('retrieval statistics', () => {
     // Only one of the successful measurements used http
     assertPointFieldValue(point, 'success_rate_http', '0.25')
   })
+  it('records retrieval stats for majority and minority results', async () => {
+    /** @type {Measurement[]} */
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xzero',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MAJORITY_RESULT'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xone',
+        retrievalResult: 'IPNI_ERROR_404',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MAJORITY_RESULT'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xtwo',
+        retrievalResult: 'TIMEOUT',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MAJORITY_RESULT'
+      },
+      // inet group 3 - score=1
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xthree',
+        retrievalResult: 'CONNECTION_REFUSED',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MAJORITY_RESULT'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xfour',
+        retrievalResult: 'HTTP_500',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MINORITY_RESULT'
+      }
+    ]
+
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+    assertPointFieldValue(point, 'total_for_success_rates', '5i')
+    assertPointFieldValue(point, 'participants', '5i')
+    assertPointFieldValue(point, 'measurements', '5i')
+    assertPointFieldValue(point, 'result_rate_OK', '0.2')
+    assertPointFieldValue(point, 'result_rate_TIMEOUT', '0.2')
+    assertPointFieldValue(point, 'result_rate_IPNI_ERROR_404', '0.2')
+    assertPointFieldValue(point, 'result_rate_CONNECTION_REFUSED', '0.2')
+    assertPointFieldValue(point, 'result_rate_HTTP_500', '0.2')
+  })
 })
 
 describe('getValueAtPercentile', () => {

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -347,7 +347,6 @@ describe('retrieval statistics', () => {
         taskingEvaluation: 'OK',
         consensusEvaluation: 'MAJORITY_RESULT'
       },
-      // inet group 3 - score=1
       {
         ...VALID_MEASUREMENT,
         participantAddress: '0xthree',

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -375,6 +375,43 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'result_rate_CONNECTION_REFUSED', '0.2')
     assertPointFieldValue(point, 'result_rate_HTTP_500', '0.2')
   })
+  it('records retrieval stats for different consensus evaluations', async () => {
+    /** @type {Measurement[]} */
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xzero',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MAJORITY_RESULT'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xone',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MINORITY_RESULT'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xtwo',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'COMMITTEE_TOO_SMALL'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xfour',
+        taskingEvaluation: 'OK',
+        consensusEvaluation: 'MAJORITY_NOT_FOUND'
+      }
+    ]
+
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+    assertPointFieldValue(point, 'total_for_success_rates', '4i')
+    assertPointFieldValue(point, 'participants', '4i')
+    assertPointFieldValue(point, 'measurements', '4i')
+    assertPointFieldValue(point, 'result_rate_OK', '1')
+  })
 })
 
 describe('getValueAtPercentile', () => {


### PR DESCRIPTION
Adds valid minority measurement results to the reported honest retrieval stats. 
Closes #446
Related to https://github.com/CheckerNetwork/spark-evaluate/pull/442#discussion_r1908899364