### PR TITLE
fix: skip downloading CIDs for empty files

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -156,6 +156,11 @@ export const preprocess = async ({
  * @returns {Promise<import('./typings.js').RawMeasurement[]>}
  */
 export const fetchMeasurements = async (cid, { signal, noCache = false } = {}) => {
+  if (cid === 'bafkqaaa' || cid === 'bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku') {
+    // These CIDs represent an empty file
+    return []
+  }
+
   const res = await fetch(
     `https://${encodeURIComponent(cid)}.ipfs.w3s.link?format=car`,
     {

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -4,7 +4,8 @@ import {
   preprocess,
   Measurement,
   parseMeasurements,
-  assertValidMeasurement
+  assertValidMeasurement,
+  fetchMeasurements
 } from '../lib/preprocess.js'
 import { Point } from '../lib/telemetry.js'
 import assert from 'node:assert'
@@ -83,6 +84,20 @@ describe('preprocess', () => {
   it('accepts ETH 0x address', () => {
     const converted = parseParticipantAddress('0x3356fd7D01F001f5FdA3dc032e8bA14E54C2a1a1')
     assert.strictEqual(converted, '0x3356fd7D01F001f5FdA3dc032e8bA14E54C2a1a1')
+  })
+})
+
+describe('fetchMeasurements', () => {
+  it('handles empty batch with CID bafkqaaa', async () => {
+    const cid = 'bafkqaaa'
+    const measurements = await fetchMeasurements(cid)
+    assert.deepStrictEqual(measurements, [])
+  })
+
+  it('handles empty batch with CID bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku', async () => {
+    const cid = 'bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku'
+    const measurements = await fetchMeasurements(cid)
+    assert.deepStrictEqual(measurements, [])
   })
 })
 


### PR DESCRIPTION
Some CIDs represent an empty file and Storacha returns HTTP 410 Gone error response in such case.

In this patch, I am fixing the function `fetchMeasurements` to skip the retrieval and return an empty list for such CIDs.

See also:
- https://github.com/CheckerNetwork/spark-api/pull/692
