### PR TITLE
chore: add .cache to Dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 .dockerignore
 node_modules
 .git
+.cache


### PR DESCRIPTION
Helper scripts keep measurements cached in `.cache` directory. They should not be uploaded to Fly.io when building the Docker image to deploy. This is important when deploying spark-evaluate manually in emergencies.